### PR TITLE
Removing incompatible jar file as the functionality is now included

### DIFF
--- a/flyway/linux-amd64/Dockerfile
+++ b/flyway/linux-amd64/Dockerfile
@@ -30,8 +30,5 @@ RUN curl -L https://download.red-gate.com/maven/release/org/flywaydb/enterprise/
   # Make it so any user can call /flyway/flyway 
   && ln -s /flyway/flyway /usr/local/bin/flyway
 
-# Download Microsoft Managed Identity jar
-RUN curl -o /flyway/lib/azure-identity-1.11.1.jar https://repo1.maven.org/maven2/com/azure/azure-identity/1.11.1/azure-identity-1.11.1.jar 
-
 # Octopus expects to start in the default directory
 WORKDIR /

--- a/flyway/linux-arm64/Dockerfile
+++ b/flyway/linux-arm64/Dockerfile
@@ -30,8 +30,5 @@ RUN curl -L https://download.red-gate.com/maven/release/org/flywaydb/enterprise/
   # Make it so any user can call /flyway/flyway 
   && ln -s /flyway/flyway /usr/local/bin/flyway
 
-# Download Microsoft Managed Identity jar
-RUN curl -o /flyway/lib/azure-identity-1.11.1.jar https://repo1.maven.org/maven2/com/azure/azure-identity/1.11.1/azure-identity-1.11.1.jar 
-
 # Octopus expects to start in the default directory
 WORKDIR /


### PR DESCRIPTION
Redgate informed us that the Azure Managed Identity jar is now bundled with the latest version of flyway.  The jar that change removes is incompatible and causing Azure Managed Identity logins to fail.