### PR TITLE
Adding gcloud CLI installation to Linux K8s-workertools

### DIFF
--- a/.github/workflows/k8s-docker-build-push.yml
+++ b/.github/workflows/k8s-docker-build-push.yml
@@ -129,6 +129,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       KUBECTL_MAJOR_MINOR_VERSION: ${{ needs.get-version-number.outputs.KUBECTL_MAJOR_MINOR_VERSION }}
+      GCLOUD_CLI_VERSION: ${{ needs.get-version-number.outputs.GCLOUD_CLI_VERSION }}
     steps:
 
     - name: Prepare
@@ -164,6 +165,7 @@ jobs:
         build-args: |
           BASE_IMAGE=${{ env.REGISTRY_IMAGE_BASE }}
           KUBECTL_MAJOR_MINOR_VERSION=${{ env.KUBECTL_MAJOR_MINOR_VERSION }}
+          GCLOUD_CLI_VERSION=${{ env.GCLOUD_CLI_VERSION }}
         outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
     - name: Export digest

--- a/.github/workflows/k8s-docker-build-push.yml
+++ b/.github/workflows/k8s-docker-build-push.yml
@@ -165,7 +165,7 @@ jobs:
         build-args: |
           BASE_IMAGE=${{ env.REGISTRY_IMAGE_BASE }}
           KUBECTL_MAJOR_MINOR_VERSION=${{ env.KUBECTL_MAJOR_MINOR_VERSION }}
-          GCLOUD_CLI_VERSION=${{ env.GCLOUD_CLI_VERSION }}
+          GOOGLE_CLOUD_CLI_VERSION=${{ env.GCLOUD_CLI_VERSION }}
         outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
     - name: Export digest

--- a/.github/workflows/k8s-docker-build-push.yml
+++ b/.github/workflows/k8s-docker-build-push.yml
@@ -165,7 +165,6 @@ jobs:
         build-args: |
           BASE_IMAGE=${{ env.REGISTRY_IMAGE_BASE }}
           KUBECTL_MAJOR_MINOR_VERSION=${{ env.KUBECTL_MAJOR_MINOR_VERSION }}
-          GOOGLE_CLOUD_CLI_VERSION=${{ env.GCLOUD_CLI_VERSION }}
         outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
     - name: Export digest

--- a/.github/workflows/k8s-docker-build-push.yml
+++ b/.github/workflows/k8s-docker-build-push.yml
@@ -129,7 +129,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       KUBECTL_MAJOR_MINOR_VERSION: ${{ needs.get-version-number.outputs.KUBECTL_MAJOR_MINOR_VERSION }}
-      GCLOUD_CLI_VERSION: ${{ needs.get-version-number.outputs.GCLOUD_CLI_VERSION }}
     steps:
 
     - name: Prepare

--- a/.github/workflows/k8s-ghcr-build-push.yml
+++ b/.github/workflows/k8s-ghcr-build-push.yml
@@ -134,7 +134,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       KUBECTL_MAJOR_MINOR_VERSION: ${{ needs.get-version-number.outputs.KUBECTL_MAJOR_MINOR_VERSION }}
-      GCLOUD_CLI_VERSION: ${{ needs.get-version-number.outputs.GCLOUD_CLI_VERSION }}
     steps:
 
     - name: Prepare

--- a/.github/workflows/k8s-ghcr-build-push.yml
+++ b/.github/workflows/k8s-ghcr-build-push.yml
@@ -133,6 +133,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       KUBECTL_MAJOR_MINOR_VERSION: ${{ needs.get-version-number.outputs.KUBECTL_MAJOR_MINOR_VERSION }}
+      GCLOUD_CLI_VERSION: ${{ needs.get-version-number.outputs.GCLOUD_CLI_VERSION }}
     steps:
 
     - name: Prepare
@@ -169,6 +170,7 @@ jobs:
         build-args: |
           BASE_IMAGE=${{ env.REGISTRY_IMAGE_BASE }}
           KUBECTL_MAJOR_MINOR_VERSION=${{ env.KUBECTL_MAJOR_MINOR_VERSION }}
+          GOOGLE_CLOUD_CLI_VERSION=${{ env.GCLOUD_CLI_VERSION }}
         outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
     - name: Export digest
@@ -186,7 +188,7 @@ jobs:
         retention-days: 1
   build-win-2022:
     needs: [get-version-number]
-    if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
+    if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }} 
     runs-on: windows-2022
     env:
       VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}

--- a/.github/workflows/k8s-ghcr-build-push.yml
+++ b/.github/workflows/k8s-ghcr-build-push.yml
@@ -67,6 +67,7 @@ jobs:
             throw "No GCLOUD CLI version with digest $latestDigest found"
         }
         else {
+            Write-Output "GCLOUD CLI version: $GCLOUD_CLI_VERSION"
             echo "GCLOUD_CLI_VERSION=$GCLOUD_CLI_VERSION" >> $env:GITHUB_OUTPUT
         }
 

--- a/.github/workflows/k8s-ghcr-build-push.yml
+++ b/.github/workflows/k8s-ghcr-build-push.yml
@@ -171,7 +171,6 @@ jobs:
         build-args: |
           BASE_IMAGE=${{ env.REGISTRY_IMAGE_BASE }}
           KUBECTL_MAJOR_MINOR_VERSION=${{ env.KUBECTL_MAJOR_MINOR_VERSION }}
-          GOOGLE_CLOUD_CLI_VERSION=${{ env.GCLOUD_CLI_VERSION }}
         outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
     - name: Export digest

--- a/k8s/linux-amd64/Dockerfile
+++ b/k8s/linux-amd64/Dockerfile
@@ -46,7 +46,10 @@ RUN curl --silent -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" 
 # See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    #apt-get update && apt-get install -y google-cloud-sdk=${GOOGLE_CLOUD_CLI_VERSION} \
     apt-get update && apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+
+RUN apt-get install -y google-cloud-sdk=${GOOGLE_CLOUD_CLI_VERSION}
 
 # Get the Istio CLI
 # https://istio.io/docs/ops/diagnostic-tools/istioctl/
@@ -68,12 +71,7 @@ RUN apt-get update && apt-get install -y skopeo
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
-# Install Google Cloud CLI
-# https://cloud.google.com/sdk/docs/downloads-apt-get
-RUN apt-get install -y ca-certificates gnupg && \
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y google-cloud-sdk=${GOOGLE_CLOUD_CLI_VERSION}
+
 
 # AZ Powershell Modules
 RUN pwsh -c 'Install-Module -Name Az -Repository PSGallery -Scope AllUsers -AllowClobber -Force'

--- a/k8s/linux-amd64/Dockerfile
+++ b/k8s/linux-amd64/Dockerfile
@@ -44,10 +44,13 @@ RUN curl --silent -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" 
 # Get gke-gcloud-auth-plugin (reqd for kubectl 1.26+)
 # See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y google-cloud-cli \
-    apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+    #echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+    #apt-get update && apt-get install -y google-cloud-cli \
+    #apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
+RUN apt-get update && apt-get install -y google-cloud-cli
+RUN apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Get the Istio CLI
 # https://istio.io/docs/ops/diagnostic-tools/istioctl/

--- a/k8s/linux-amd64/Dockerfile
+++ b/k8s/linux-amd64/Dockerfile
@@ -44,7 +44,6 @@ RUN curl --silent -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" 
 # Get gke-gcloud-auth-plugin (reqd for kubectl 1.26+)
 # See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    #echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 
 RUN apt-get update && apt-get install -y google-cloud-cli
@@ -69,8 +68,6 @@ RUN apt-get update && apt-get install -y skopeo
 # Get Azure CLI
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
-
-
 
 # AZ Powershell Modules
 RUN pwsh -c 'Install-Module -Name Az -Repository PSGallery -Scope AllUsers -AllowClobber -Force'

--- a/k8s/linux-amd64/Dockerfile
+++ b/k8s/linux-amd64/Dockerfile
@@ -3,6 +3,7 @@ FROM --platform=linux/amd64 ${BASE_IMAGE}:latest
 
 ARG DEBIAN_FRONTEND noninteractive
 ARG KUBECTL_MAJOR_MINOR_VERSION=1.29
+ARG GOOGLE_CLOUD_CLI_VERSION=462.0.0-0
 
 # Get kubectl
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
@@ -66,6 +67,13 @@ RUN apt-get update && apt-get install -y skopeo
 # Get Azure CLI
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+# Install Google Cloud CLI
+# https://cloud.google.com/sdk/docs/downloads-apt-get
+RUN apt-get install -y ca-certificates gnupg && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get update && apt-get install -y google-cloud-sdk=${GOOGLE_CLOUD_CLI_VERSION}
 
 # AZ Powershell Modules
 RUN pwsh -c 'Install-Module -Name Az -Repository PSGallery -Scope AllUsers -AllowClobber -Force'

--- a/k8s/linux-amd64/Dockerfile
+++ b/k8s/linux-amd64/Dockerfile
@@ -3,7 +3,6 @@ FROM --platform=linux/amd64 ${BASE_IMAGE}:latest
 
 ARG DEBIAN_FRONTEND noninteractive
 ARG KUBECTL_MAJOR_MINOR_VERSION=1.29
-ARG GOOGLE_CLOUD_CLI_VERSION=462.0.0-0
 
 # Get kubectl
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
@@ -46,10 +45,9 @@ RUN curl --silent -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" 
 # See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    #apt-get update && apt-get install -y google-cloud-sdk=${GOOGLE_CLOUD_CLI_VERSION} \
-    apt-get update && apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+    apt-get update && apt-get install -y google-cloud-cli \
+    apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
-RUN apt-get install -y google-cloud-sdk=${GOOGLE_CLOUD_CLI_VERSION}
 
 # Get the Istio CLI
 # https://istio.io/docs/ops/diagnostic-tools/istioctl/

--- a/k8s/linux-amd64/Dockerfile
+++ b/k8s/linux-amd64/Dockerfile
@@ -46,8 +46,6 @@ RUN curl --silent -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" 
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     #echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-    #apt-get update && apt-get install -y google-cloud-cli \
-    #apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 RUN apt-get update && apt-get install -y google-cloud-cli
 RUN apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin

--- a/k8s/linux-arm64/Dockerfile
+++ b/k8s/linux-arm64/Dockerfile
@@ -3,6 +3,7 @@ FROM --platform=linux/arm64 ${BASE_IMAGE}:latest
 
 ARG DEBIAN_FRONTEND noninteractive
 ARG KUBECTL_MAJOR_MINOR_VERSION=1.29
+ARG GOOGLE_CLOUD_CLI_VERSION=462.0.0-0
 
 # Get kubectl
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management
@@ -63,6 +64,13 @@ RUN apt-get update && apt-get install -y skopeo
 # Get Azure CLI
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
+# Install Google Cloud CLI
+# https://cloud.google.com/sdk/docs/downloads-apt-get
+RUN apt-get install -y ca-certificates gnupg && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get update && apt-get install -y google-cloud-sdk=${GOOGLE_CLOUD_CLI_VERSION}
 
 # JQ
 RUN apt-get install -y jq

--- a/k8s/linux-arm64/Dockerfile
+++ b/k8s/linux-arm64/Dockerfile
@@ -41,10 +41,21 @@ RUN curl --silent -L "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
 
 # Get gke-gcloud-auth-plugin (reqd for kubectl 1.26+)
 # See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
+#RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+#    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+#    apt-get update && apt-get install -y google-cloud-cli \
+#    apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+
+# Get gke-gcloud-auth-plugin (reqd for kubectl 1.26+)
+# See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y google-cloud-cli \
-    apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+#echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+#apt-get update && apt-get install -y google-cloud-cli \
+#apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+
+RUN apt-get update && apt-get install -y google-cloud-cli
+RUN apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Get the Istio CLI
 # https://istio.io/docs/ops/diagnostic-tools/istioctl/
@@ -65,13 +76,6 @@ RUN apt-get update && apt-get install -y skopeo
 # Get Azure CLI
 # https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
-
-# Install Google Cloud CLI
-# https://cloud.google.com/sdk/docs/downloads-apt-get
-RUN apt-get install -y ca-certificates gnupg && \
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y google-cloud-sdk=${GOOGLE_CLOUD_CLI_VERSION}
 
 # JQ
 RUN apt-get install -y jq

--- a/k8s/linux-arm64/Dockerfile
+++ b/k8s/linux-arm64/Dockerfile
@@ -43,7 +43,8 @@ RUN curl --silent -L "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
 # See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+    apt-get update && apt-get install -y google-cloud-cli \
+    apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Get the Istio CLI
 # https://istio.io/docs/ops/diagnostic-tools/istioctl/

--- a/k8s/linux-arm64/Dockerfile
+++ b/k8s/linux-arm64/Dockerfile
@@ -3,7 +3,6 @@ FROM --platform=linux/arm64 ${BASE_IMAGE}:latest
 
 ARG DEBIAN_FRONTEND noninteractive
 ARG KUBECTL_MAJOR_MINOR_VERSION=1.29
-ARG GOOGLE_CLOUD_CLI_VERSION=462.0.0-0
 
 # Get kubectl
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-using-native-package-management

--- a/k8s/linux-arm64/Dockerfile
+++ b/k8s/linux-arm64/Dockerfile
@@ -39,20 +39,11 @@ RUN curl --silent -L "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
     ./aws/install && \
     rm -f awscliv2.zip
 
-# Get gke-gcloud-auth-plugin (reqd for kubectl 1.26+)
-# See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
-#RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-#    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-#    apt-get update && apt-get install -y google-cloud-cli \
-#    apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Get gke-gcloud-auth-plugin (reqd for kubectl 1.26+)
 # See https://github.com/OctopusDeploy/Issues/issues/7621 for more info
 RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-#echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-#apt-get update && apt-get install -y google-cloud-cli \
-#apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 RUN apt-get update && apt-get install -y google-cloud-cli
 RUN apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin


### PR DESCRIPTION
Disregard the branch name, it actually updates the k8s-workertools images to include the gcloud CLI.  The Windows version did this, just not the Linux ones (amd64, arm64).  This updates the image so it can be used with GKE.