### PR TITLE
Adds the latest Trivy CLI version to the GitHub execution containers

### DIFF
--- a/github-cli/linux-amd64/Dockerfile
+++ b/github-cli/linux-amd64/Dockerfile
@@ -44,4 +44,13 @@ RUN apt-get install -y ca-certificates gnupg && \
     curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get update && apt-get install -y google-cloud-sdk
+
+## Install Trivy
+RUN apt-get update && \
+    apt-get install -y wget apt-transport-https gnupg lsb-release && \
+    wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | apt-key add - && \
+    echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main > /etc/apt/sources.list.d/trivy.list && \
+    apt-get update && \
+    apt-get install -y trivy && \
+    rm -rf /var/lib/apt/lists/*
     

--- a/github-cli/linux-arm64/Dockerfile
+++ b/github-cli/linux-arm64/Dockerfile
@@ -43,3 +43,12 @@ RUN apt-get install -y ca-certificates gnupg && \
     curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get update && apt-get install -y google-cloud-sdk
+
+## Install Trivy
+RUN apt-get update && \
+    apt-get install -y wget apt-transport-https gnupg lsb-release && \
+    wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | apt-key add - && \
+    echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main > /etc/apt/sources.list.d/trivy.list && \
+    apt-get update && \
+    apt-get install -y trivy && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The GitHub CLI allows you to verify GitHub attestations for zip/nuget/jar/war packages as well as containrs.  The code to get the containers and for the GitHub attestation CLI to work is no picnic.  If someone also wanted to run a Trivy verification in addition to the GH attestation verification, they'd like want to do it at the same time.

This update will allow that to happen.