### PR TITLE
Add Azcopy installation to Azure images

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This image contains all the necessary tooling to deploy to [Azure](https://azure
 - Azure CLI
 - Azure PowerShell (Az Modules)
 - TerraForm
+- Azcopy
 
 A new image is built each time a new version of Azure CLI is detected. The version numbers will be based on the version of the Azure CLI.
 

--- a/azure/linux-amd64/Dockerfile
+++ b/azure/linux-amd64/Dockerfile
@@ -16,3 +16,9 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 # Get AZ Powershell core modules
 # https://learn.microsoft.com/en-us/powershell/azure/install-azure-powershell?view=azps-11.2.0
 RUN pwsh -c 'Install-Module -Name Az -Repository PSGallery -Scope AllUsers -AllowClobber -Force'
+
+# Get AZCopy
+# https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-install-linux-package?tabs=apt
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm main" | tee /etc/apt/sources.list.d/microsoft.list && \
+    apt update && apt install -y azcopy

--- a/azure/linux-amd64/Dockerfile
+++ b/azure/linux-amd64/Dockerfile
@@ -19,6 +19,9 @@ RUN pwsh -c 'Install-Module -Name Az -Repository PSGallery -Scope AllUsers -Allo
 
 # Get AZCopy
 # https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-install-linux-package?tabs=apt
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm main" | tee /etc/apt/sources.list.d/microsoft.list && \
-    apt update && apt install -y azcopy
+RUN set -eux; \
+    curl -sSL "https://aka.ms/downloadazcopy-v10-linux" -o azcopy.tar.gz; \
+    tar -xzf azcopy.tar.gz; \
+    mv azcopy_linux_*/azcopy /usr/local/bin/; \
+    chmod +x /usr/local/bin/azcopy; \
+    rm -rf azcopy_linux_* azcopy.tar.gz

--- a/azure/linux-arm64/Dockerfile
+++ b/azure/linux-arm64/Dockerfile
@@ -16,3 +16,9 @@ RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 # Get AZ Powershell core modules
 # https://learn.microsoft.com/en-us/powershell/azure/install-azure-powershell?view=azps-11.2.0
 RUN pwsh -c 'Install-Module -Name Az -Repository PSGallery -Scope AllUsers -AllowClobber -Force'
+
+# Get AZCopy
+# https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-install-linux-package?tabs=apt
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm main" | tee /etc/apt/sources.list.d/microsoft.list && \
+    apt update && apt install -y azcopy

--- a/azure/linux-arm64/Dockerfile
+++ b/azure/linux-arm64/Dockerfile
@@ -19,6 +19,9 @@ RUN pwsh -c 'Install-Module -Name Az -Repository PSGallery -Scope AllUsers -Allo
 
 # Get AZCopy
 # https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-install-linux-package?tabs=apt
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-debian-bookworm-prod bookworm main" | tee /etc/apt/sources.list.d/microsoft.list && \
-    apt update && apt install -y azcopy
+RUN set -eux; \
+    curl -sSL "https://aka.ms/downloadazcopy-v10-linux-arm64" -o azcopy.tar.gz; \
+    tar -xzf azcopy.tar.gz; \
+    mv azcopy_linux_*/azcopy /usr/local/bin/; \
+    chmod +x /usr/local/bin/azcopy; \
+    rm -rf azcopy_linux_* azcopy.tar.gz

--- a/azure/windows-2022/Dockerfile
+++ b/azure/windows-2022/Dockerfile
@@ -9,6 +9,9 @@ RUN choco install terraform -y --no-progress
 # Install Azure CLI
 RUN choco install azure-cli -y --no-progress
 
+# Install Azcopy
+RUN choco install azcopy10 -y --no-progress
+
 RUN Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force; `
     Install-Module -Force -Name Az -AllowClobber -Scope AllUsers
 


### PR DESCRIPTION
This PR will add azcopy into the Azure image, and update the readme.

I have a use case coming up where I want to use azcopy in a deployment process, and having it preinstalled in a container I can use as an execution container means I don't need to reinstall it on each deployment.

Please let me know if I've missed anything!